### PR TITLE
feat(swiper): use quadratic instead of linear

### DIFF
--- a/tests/renders/card.spec.ts
+++ b/tests/renders/card.spec.ts
@@ -10,8 +10,8 @@
 import Card from '../../src/renders/card';
 
 describe('test card render', () => {
-    const slide;
-    const mockSwiper;
+    let slide;
+    let mockSwiper;
 
     beforeEach(() => {
         slide = new Card();
@@ -20,10 +20,8 @@ describe('test card render', () => {
     test('normal card render in Y', () => {
         mockSwiper = {
             axis: 'Y',
-            offset: {
-                Y: -65
-            },
-            sideLength: 650;
+            sideOffset: -65,
+            sideLength: 650
         };
         
         let transform = slide.doRender(mockSwiper);
@@ -35,10 +33,8 @@ describe('test card render', () => {
     test('normal card render in X', () => {
         mockSwiper = {
             axis: 'X',
-            offset: {
-                X: -200
-            },
-            sideLength: 400;
+            sideOffset: -200,
+            sideLength: 400
         };
         
         let transform = slide.doRender(mockSwiper);
@@ -50,10 +46,8 @@ describe('test card render', () => {
     test('normal card render for positive offset', () => {
         mockSwiper = {
             axis: 'Y',
-            offset: {
-                Y: 65
-            },
-            sideLength: 650;
+            sideOffset: 65,
+            sideLength: 650
         };
         
         let transform = slide.doRender(mockSwiper);
@@ -65,10 +59,8 @@ describe('test card render', () => {
     test('normal card render for 0 offset', () => {
         mockSwiper = {
             axis: 'Y',
-            offset: {
-                Y: 0
-            },
-            sideLength: 650;
+            sideOffset: 0,
+            sideLength: 650
         };
         
         let transform = slide.doRender(mockSwiper);
@@ -80,10 +72,8 @@ describe('test card render', () => {
     test('test sign function', () => {
         mockSwiper = {
             axis: 'Y',
-            offset: {
-                Y: -65
-            },
-            sideLength: 650;
+            sideOffset: -65,
+            sideLength: 650
         };
         
         slide.sign = jest.fn();

--- a/tests/renders/dumi.spec.ts
+++ b/tests/renders/dumi.spec.ts
@@ -10,17 +10,15 @@
 import Dumi from '../../src/renders/dumi';
 
 describe('test dumi render', () => {
-    const slide;
-    const mockSwiper;
+    let slide;
+    let mockSwiper;
 
     beforeEach(() => {
         slide = new Dumi();
         mockSwiper = {
             axis: 'Y',
-            offset: {
-                Y: -325
-            },
-            sideLength: 650;
+            sideOffset: -325,
+            sideLength: 650
         };
     });
 

--- a/tests/renders/fade.spec.ts
+++ b/tests/renders/fade.spec.ts
@@ -11,17 +11,15 @@ import Fade from '../../src/renders/fade';
 
 
 describe('test fade render', () => {
-    const slide;
-    const mockSwiper;
+    let slide;
+    let mockSwiper;
 
     beforeEach(() => {
         slide = new Fade();
         mockSwiper = {
             axis: 'Y',
-            offset: {
-                Y: -65
-            },
-            sideLength: 650;
+            sideOffset: -65,
+            sideLength: 650
         };
     });
 

--- a/tests/renders/flip.spec.ts
+++ b/tests/renders/flip.spec.ts
@@ -11,17 +11,15 @@ import Flip from '../../src/renders/flip';
 
 
 describe('test flip render', () => {
-    const slide;
-    const mockSwiper;
+    let slide;
+    let mockSwiper;
 
     beforeEach(() => {
         slide = new Flip();
         mockSwiper = {
             axis: 'Y',
-            offset: {
-                Y: -65
-            },
-            sideLength: 650;
+            sideOffset: -65,
+            sideLength: 650
         };
     });
 

--- a/tests/renders/rotate.spec.ts
+++ b/tests/renders/rotate.spec.ts
@@ -11,17 +11,15 @@ import Rotate from '../../src/renders/rotate';
 
 
 describe('test rotate render', () => {
-    const slide;
-    const mockSwiper;
+    let slide;
+    let mockSwiper;
 
     beforeEach(() => {
         slide = new Rotate();
         mockSwiper = {
             axis: 'Y',
-            offset: {
-                Y: -65
-            },
-            sideLength: 650;
+            sideOffset: -65,
+            sideLength: 650
         };
     });
 

--- a/tests/renders/slide.spec.ts
+++ b/tests/renders/slide.spec.ts
@@ -10,17 +10,15 @@
 import Slide from '../../src/renders/slide';
 
 describe('test slide render', () => {
-    const slide;
-    const mockSwiper;
+    let slide;
+    let mockSwiper;
 
     beforeEach(() => {
         slide = new Slide();
         mockSwiper = {
             axis: 'Y',
-            offset: {
-                Y: -100
-            },
-            sideLength: 650;
+            sideOffset: -100,
+            sideLength: 650
         };
 
     });


### PR DESCRIPTION
1. use quadratic instead of linear when rendering
2. add back container's overflow style
3. adjust test files respectively