### PR TITLE
fix(swiper): directly return when page is forbidding bi-direction swiper

### DIFF
--- a/src/swiper.ts
+++ b/src/swiper.ts
@@ -209,11 +209,15 @@ export class Swiper {
         this.transition = {...this.transition, ...this.currentPage.transition};
         this.renderInstance = Render.getRenderInstance(this.transition.name);
 
+        if (this.transition.direction === Direction.Nonward) {
+            return;
+        }
+        
         this.fire('swipeStart');
     }
 
     private moveHandler(movingPosition: Point) {
-        if (this.sliding || !this.moving) {
+        if (this.sliding || !this.moving || this.transition.direction === Direction.Nonward) {
     		return;
     	}
 
@@ -251,8 +255,7 @@ export class Swiper {
         // 页面禁止滑动时
         // 防止突然「先上后下」，直接将 this.offset 置为 0
         // 防止需要「等」 offset 归 0 后才能往上走
-        if (this.transition.direction === Direction.Nonward
-        || (this.transition.direction && this.transition.direction !== this.moveDirection)) {
+        if (this.transition.direction && this.transition.direction !== this.moveDirection) {
             this.offset[this.axis] = 0;
             this.start = this.end;
         }
@@ -278,7 +281,7 @@ export class Swiper {
     }
 
     private endHandler() {
-        if (this.sliding || !this.moving) {
+        if (this.sliding || !this.moving  || this.transition.direction === Direction.Nonward) {
     		return;
     	}
         
@@ -286,8 +289,7 @@ export class Swiper {
         this.log('end');
 
         // 如果禁止滑动
-        if (this.transition.direction === Direction.Nonward
-        || (this.transition.direction && this.transition.direction !== this.moveDirection)) {
+        if (this.transition.direction && this.transition.direction !== this.moveDirection) {
             this.offset[this.axis] = 0;
         }
 

--- a/tests/swiper.spec.ts
+++ b/tests/swiper.spec.ts
@@ -350,12 +350,15 @@ describe('test swiper', () => {
                     direction: 0
                 }
             });
+            swiper.fire = jest.fn();
 
             swiper.startHandler(mockStartPoint);
             swiper.moveHandler(mockDownMovingPoint);
+            swiper.endHandler();
 
             expect(swiper.offset.Y).toBe(0);
-            expect(swiper.start).toEqual(mockDownMovingPoint);
+            expect(swiper.start).toEqual(mockStartPoint);
+            expect(swiper.fire).not.toBeCalled();
         });
 
         test('test page down forbidden in moving event', () => {
@@ -369,12 +372,18 @@ describe('test swiper', () => {
                     direction: -1
                 }
             });
+            swiper.fire = jest.fn();
 
             swiper.startHandler(mockStartPoint);
             swiper.moveHandler(mockDownMovingPoint);
+            swiper.endHandler();
 
             expect(swiper.offset.Y).toBe(0);
             expect(swiper.start).toEqual(mockDownMovingPoint);
+            expect(swiper.fire).toBeCalledWith('swipeStart');
+            expect(swiper.fire).toBeCalledWith('swipeMoving');
+            expect(swiper.fire).toBeCalledWith('activePageChanged');
+            expect(swiper.fire).toBeCalledWith('swipeRestore');
         });
 
          test('test debug option', () => {


### PR DESCRIPTION
As we know this after touchStart

HINT:
1. When we want to apply above to single direction forbidden scene, but failed. Since the quick switch between two direction, if we do not render in moving handler, the page will be stuck.