### PR TITLE
fix(device): fixed detect method of supporting Touch Event

### DIFF
--- a/src/device.ts
+++ b/src/device.ts
@@ -35,7 +35,7 @@ export class Device {
     public transitionEvent: string;
 
     constructor(global) {
-        this.hasTouch = !!(('ontouchstart' in global && !/Mac OS X /.test(global.navigator.userAgent))
+        this.hasTouch = !!('ontouchstart' in global
         || (global.DocumentTouch && global.document instanceof global.DocumentTouch));
 
         this.startEvent = this.hasTouch ? 'touchstart' : 'mousedown';


### PR DESCRIPTION
BUG: In baidubox, some iOS, userAgent is ‘Mozilla/5.0 (iPhone; CPU iPhone OS 11_1_2 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) BaiduBoxApp/10.0.0 iPhone; CPU iPhone OS 11_1_2 like Mac OS X Mobile/15B202 Safari/602.1 baiduboxapp/10.0.6.11 (Baidu; P2 11.1.2)’

FIX: Refer from modernizr library detect method https://github.com/Modernizr/Modernizr/blob/master/feature-detects/touchevents.js#L40